### PR TITLE
docs: add initial project documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+This repository is a fresh rebuild of [0xf000h.dev](https://0xf000h.dev). Treat it as an intentionally new project, not a direct port of the previous site.
+
+## Operating Principles
+
+- The repository owner makes product, design, content, and branding decisions.
+- Agents are implementation partners and should not make major product or design decisions without direction.
+- Prefer clear, maintainable code and clean project structure over cleverness.
+- Keep changes incremental, reviewable, and tightly scoped to the requested task.
+- Avoid unrelated refactors or opportunistic cleanup unless explicitly requested.
+- Avoid unnecessary dependencies, abstractions, and early framework commitments.
+
+## Expectations For Changes
+
+- Document assumptions explicitly when requirements are incomplete.
+- Choose the simplest approach that preserves future flexibility.
+- Make small PR-friendly edits that are easy to reason about and review.
+- Preserve existing intent and repository conventions when adding new work.
+- If a decision would materially affect product direction, stop and ask.
+
+## Workflow Guidance
+
+- Prefer conventional commits.
+- Use branch names such as `docs/*`, `feat/*`, and `chore/*`.
+- Assume the project will be deployed on Vercel, but do not lock in implementation details before they are requested.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # 0xf000h-v2
-Modern site rebuild
+
+Fresh rebuild of [0xf000h.dev](https://0xf000h.dev).
+
+This repository is the clean-slate v2 of the personal site. It replaces an older Next.js site previously deployed on Vercel, but it is intentionally not a direct port. The goal is to rebuild the site from first principles, with clearer structure, tighter scope, and better long-term maintainability.
+
+## Goals
+
+- Rebuild the site deliberately instead of copying the previous implementation.
+- Keep product, design, and branding decisions explicit and intentional.
+- Optimize for maintainable code, simple architecture, and small reviewable changes.
+- Prepare the project for deployment on Vercel without locking in the final stack too early.
+
+## Collaboration
+
+- The repository owner is the designer and product owner.
+- Implementation work should follow the owner's direction on product, design, content, and branding.
+- Changes should be incremental, easy to review, and clearly scoped to the requested task.
+- Assumptions and tradeoffs should be documented explicitly when they affect implementation.
+
+## Workflow
+
+- Start small and build the project in thin vertical slices.
+- Prefer discussion and documentation before introducing framework or architecture commitments.
+- Keep pull requests focused on one concern at a time.
+- Avoid unrelated refactors while the project foundation is still being established.
+
+## Git Conventions
+
+- Use conventional commits.
+- Use descriptive branch names such as `docs/*`, `feat/*`, and `chore/*`.
+- Keep the first PR small and reviewable.


### PR DESCRIPTION
## Summary
- add a real README for the v2 rebuild of 0xf000h.dev
- add a repo-level AGENTS.md with implementation guardrails
- keep the initial PR limited to documentation only

## Notes
- no app scaffolding
- no dependencies installed
- no framework or stack decisions made yet