### PR TITLE
feat: add initial design system foundation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,16 +1,132 @@
 @import "tailwindcss";
 
 :root {
+  --background: oklch(0.982 0.006 85);
+  --foreground: oklch(0.238 0.018 258);
+  --muted: oklch(0.954 0.004 85);
+  --muted-foreground: oklch(0.52 0.015 255);
+  --surface: oklch(0.995 0.002 85 / 0.84);
+  --surface-strong: oklch(0.966 0.006 85 / 0.94);
+  --border: oklch(0.884 0.01 85 / 0.82);
+  --border-strong: oklch(0.792 0.014 250 / 0.9);
+  --accent: oklch(0.5 0.11 245);
+  --accent-foreground: oklch(0.985 0.002 85);
+  --ring: oklch(0.63 0.09 244 / 0.55);
+  --grid: oklch(0.9 0.01 85 / 0.55);
+
+  --text-lede: clamp(1.05rem, 0.98rem + 0.35vw, 1.28rem);
+  --space-gutter: clamp(1.25rem, 0.9rem + 1vw, 2.25rem);
+  --space-section: clamp(4rem, 2.8rem + 4vw, 7rem);
+  --layout-content: 42rem;
+  --layout-wide: 72rem;
+
+  --radius-sm: 0.75rem;
+  --radius-md: 1rem;
+  --radius-lg: 1.5rem;
+  --radius-xl: 2rem;
+
+  --shadow-soft: 0 10px 30px -22px rgb(15 23 42 / 0.35);
+  --shadow-panel: 0 24px 60px -32px rgb(15 23 42 / 0.28);
+
   color-scheme: light;
+}
+
+.dark {
+  --background: oklch(0.205 0.02 258);
+  --foreground: oklch(0.94 0.008 85);
+  --muted: oklch(0.27 0.018 255);
+  --muted-foreground: oklch(0.74 0.012 85);
+  --surface: oklch(0.24 0.02 258 / 0.82);
+  --surface-strong: oklch(0.285 0.018 258 / 0.94);
+  --border: oklch(0.365 0.018 258 / 0.84);
+  --border-strong: oklch(0.49 0.022 245 / 0.9);
+  --accent: oklch(0.73 0.09 230);
+  --accent-foreground: oklch(0.205 0.02 258);
+  --ring: oklch(0.72 0.08 230 / 0.48);
+  --grid: oklch(0.4 0.018 255 / 0.36);
+
+  --shadow-soft: 0 12px 36px -26px rgb(2 6 23 / 0.7);
+  --shadow-panel: 0 28px 72px -36px rgb(2 6 23 / 0.85);
+
+  color-scheme: dark;
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-surface: var(--surface);
+  --color-surface-strong: var(--surface-strong);
+  --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-ring: var(--ring);
+  --color-grid: var(--grid);
+  --font-sans: var(--font-body);
+  --font-mono: var(--font-code);
+  --font-display: var(--font-body);
 }
 
 html {
   scroll-behavior: smooth;
+  background: var(--background);
+}
+
+* {
+  border-color: var(--border);
 }
 
 body {
   min-height: 100vh;
-  background: #fafaf9;
-  color: #111827;
-  font-family: Arial, Helvetica, sans-serif;
+  background:
+    radial-gradient(circle at top left, color-mix(in oklab, var(--accent) 10%, transparent) 0, transparent 32%),
+    linear-gradient(180deg, color-mix(in oklab, var(--surface) 42%, var(--background)) 0%, var(--background) 100%);
+  color: var(--foreground);
+  font-family: var(--font-body), sans-serif;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+::selection {
+  background: color-mix(in oklab, var(--accent) 24%, transparent);
+}
+
+main {
+  position: relative;
+}
+
+main::before {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(to right, transparent 0, transparent calc(100% - 1px), var(--grid) calc(100% - 1px)),
+    linear-gradient(to bottom, transparent 0, transparent calc(100% - 1px), var(--grid) calc(100% - 1px));
+  background-position: center top;
+  background-size: 100% 100%, 100% 8rem;
+  content: "";
+  mask-image: linear-gradient(180deg, rgb(0 0 0 / 0.28), transparent 68%);
+  pointer-events: none;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  text-wrap: balance;
+}
+
+p {
+  text-wrap: pretty;
+}
+
+:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+@utility page-frame {
+  margin-inline: auto;
+  width: min(calc(100% - (var(--space-gutter) * 2)), var(--layout-wide));
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,21 @@
 import type { Metadata } from "next";
+import { IBM_Plex_Mono, Sora } from "next/font/google";
 
 import "./globals.css";
 
+import { ThemeProvider } from "@/components/theme-provider";
 import { siteConfig } from "@/lib/site";
+
+const bodyFont = Sora({
+  subsets: ["latin"],
+  variable: "--font-body",
+});
+
+const monoFont = IBM_Plex_Mono({
+  subsets: ["latin"],
+  variable: "--font-code",
+  weight: ["400", "500"],
+});
 
 export const metadata: Metadata = {
   title: {
@@ -19,8 +32,21 @@ type RootLayoutProps = Readonly<{
 
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
-    <html lang="en">
-      <body>{children}</body>
+    <html
+      className={`${bodyFont.variable} ${monoFont.variable}`}
+      lang="en"
+      suppressHydrationWarning
+    >
+      <body>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          disableTransitionOnChange
+          enableSystem
+        >
+          {children}
+        </ThemeProvider>
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,20 +1,78 @@
 import { PageShell } from "@/components/page-shell";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 export default function HomePage() {
   return (
-    <main className="flex min-h-screen items-center justify-center px-6 py-24">
-      <PageShell>
-        <p className="text-sm font-medium uppercase tracking-[0.2em] text-neutral-500">
-          0xf000h.dev
-        </p>
-        <h1 className="mt-6 text-4xl font-semibold tracking-tight text-neutral-950 sm:text-5xl">
-          Fresh rebuild in progress.
-        </h1>
-        <p className="mt-4 max-w-2xl text-base leading-7 text-neutral-600">
-          Initial scaffold for the new personal site. Content, structure, and
-          visual direction will be added incrementally.
-        </p>
-      </PageShell>
+    <main className="min-h-screen py-[var(--space-section)]">
+      <div className="page-frame flex min-h-[calc(100vh-(var(--space-section)*2))] flex-col justify-center gap-6 sm:gap-8">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div className="space-y-2">
+            <p className="font-mono text-xs uppercase tracking-[0.28em] text-accent">
+              0xf000h.dev
+            </p>
+            <p className="max-w-xl text-sm leading-6 text-muted-foreground">
+              Foundation pass for the fresh rebuild: theme-aware tokens,
+              typography, and layout primitives before the final homepage takes
+              shape.
+            </p>
+          </div>
+
+          <ThemeToggle />
+        </div>
+
+        <PageShell className="lg:pr-16">
+          <div className="relative z-10 grid gap-10">
+            <div className="max-w-3xl space-y-5">
+              <p className="font-mono text-xs uppercase tracking-[0.24em] text-muted-foreground">
+                Initial Design System
+              </p>
+
+              <h1 className="max-w-3xl font-display text-[clamp(2.9rem,1.9rem+4vw,5.5rem)] font-semibold leading-[0.94] tracking-[-0.06em] text-foreground">
+                Minimal by intent, but no longer generic.
+              </h1>
+
+              <p className="max-w-2xl text-[length:var(--text-lede)] leading-[1.7] text-muted-foreground">
+                The site now has a stable visual language for color, type,
+                spacing, surfaces, and theme behavior. It is still a scaffold,
+                just one that is ready for design-heavy iteration.
+              </p>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-3">
+              <article className="rounded-[var(--radius-lg)] border border-border/80 bg-background/60 p-5">
+                <p className="font-mono text-[0.7rem] uppercase tracking-[0.22em] text-muted-foreground">
+                  Palette
+                </p>
+                <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                  Neutral base tones with a restrained accent, defined in light
+                  and dark tokens instead of ad hoc color classes.
+                </p>
+              </article>
+
+              <article className="rounded-[var(--radius-lg)] border border-border/80 bg-background/60 p-5">
+                <p className="font-mono text-[0.7rem] uppercase tracking-[0.22em] text-muted-foreground">
+                  Typography
+                </p>
+                <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                  Sora sets the interface tone, IBM Plex Mono handles utility
+                  text, and responsive type scales establish consistent rhythm.
+                </p>
+              </article>
+
+              <article className="rounded-[var(--radius-lg)] border border-border/80 bg-background/60 p-5">
+                <p className="font-mono text-[0.7rem] uppercase tracking-[0.22em] text-muted-foreground">
+                  Layout
+                </p>
+                <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                  Shared gutter, measure, radius, and surface rules now anchor
+                  the scaffold without committing to the final homepage
+                  composition.
+                </p>
+              </article>
+            </div>
+          </div>
+        </PageShell>
+      </div>
     </main>
   );
 }

--- a/components.json
+++ b/components.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "app/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib"
+  }
+}

--- a/components/page-shell.tsx
+++ b/components/page-shell.tsx
@@ -1,10 +1,26 @@
+import { cn } from "@/lib/utils";
+
 type PageShellProps = Readonly<{
   children: React.ReactNode;
+  className?: string;
 }>;
 
-export function PageShell({ children }: PageShellProps) {
+export function PageShell({ children, className }: PageShellProps) {
   return (
-    <section className="w-full max-w-3xl rounded-3xl border border-neutral-200 bg-white/80 p-8 shadow-sm backdrop-blur sm:p-12">
+    <section
+      className={cn(
+        "relative w-full overflow-hidden rounded-[var(--radius-xl)] border border-border bg-surface px-6 py-8 shadow-[var(--shadow-panel)] backdrop-blur-xl sm:px-10 sm:py-10 lg:px-12 lg:py-12",
+        className,
+      )}
+    >
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-x-8 top-0 h-px bg-linear-to-r from-transparent via-border-strong to-transparent"
+      />
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute -right-16 top-[-3.5rem] h-40 w-40 rounded-full bg-accent/12 blur-3xl"
+      />
       {children}
     </section>
   );

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import {
+  ThemeProvider as NextThemesProvider,
+  type ThemeProviderProps,
+} from "next-themes";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useTheme } from "next-themes";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const themeOptions = [
+  { label: "System", value: "system" },
+  { label: "Light", value: "light" },
+  { label: "Dark", value: "dark" },
+] as const;
+
+export function ThemeToggle() {
+  const { setTheme, theme } = useTheme();
+  const activeTheme = theme ?? "system";
+
+  return (
+    <div className="inline-flex items-center gap-3 rounded-[calc(var(--radius-lg)-0.375rem)] border border-border/80 bg-surface px-2 py-2 shadow-[var(--shadow-soft)] backdrop-blur-sm">
+      <div className="pl-1">
+        <p className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+          Theme
+        </p>
+        <p className="text-xs text-muted-foreground/80">
+          {activeTheme === "system" ? "Following system" : activeTheme}
+        </p>
+      </div>
+
+      <div
+        aria-label="Theme switcher"
+        className="inline-flex items-center gap-1 rounded-[calc(var(--radius-md)-0.125rem)] border border-border/70 bg-background/80 p-1"
+        role="group"
+      >
+        {themeOptions.map((option) => {
+          const isActive = option.value === activeTheme;
+
+          return (
+            <Button
+              key={option.value}
+              aria-pressed={isActive}
+              className={cn(
+                "min-w-16 rounded-[calc(var(--radius-sm)-0.125rem)] px-3",
+                isActive &&
+                  "border-transparent bg-foreground text-background hover:bg-foreground",
+              )}
+              onClick={() => setTheme(option.value)}
+              size="sm"
+              type="button"
+              variant={isActive ? "default" : "ghost"}
+            >
+              {option.label}
+            </Button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[var(--radius-sm)] border text-sm font-medium transition-[background-color,border-color,color,box-shadow] duration-150 disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-foreground text-background shadow-[0_12px_32px_-18px_rgb(15_23_42_/_0.45)] hover:bg-foreground/92",
+        secondary:
+          "border-border bg-surface-strong text-foreground hover:border-border-strong hover:bg-surface",
+        ghost:
+          "border-transparent bg-transparent text-muted-foreground hover:bg-muted hover:text-foreground",
+        outline:
+          "border-border bg-transparent text-foreground hover:border-border-strong hover:bg-muted",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-8 px-3 text-xs tracking-[0.04em]",
+        lg: "h-11 px-5 text-base",
+        icon: "size-10",
+      },
+    },
+    defaultVariants: {
+      variant: "secondary",
+      size: "default",
+    },
+  },
+);
+
+type ButtonProps = React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  };
+
+export function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: ButtonProps) {
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size }), className)}
+      {...props}
+    />
+  );
+}
+
+export { buttonVariants };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/package.json
+++ b/package.json
@@ -10,9 +10,14 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.4",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "next": "^16.1.6",
+    "next-themes": "^0.4.6",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,30 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-slot':
+        specifier: ^1.2.4
+        version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       next:
         specifier: ^16.1.6
         version: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.2.4
         version: 19.2.4
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.2.1
@@ -428,6 +443,24 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.4':
+    resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -837,8 +870,15 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1540,6 +1580,12 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+
   next@16.1.6:
     resolution: {integrity: sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==}
     engines: {node: '>=20.9.0'}
@@ -1838,6 +1884,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
   tailwindcss@4.2.1:
     resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
@@ -2302,6 +2351,19 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@rtsao/scc@1.1.0': {}
 
   '@swc/helpers@0.5.15':
@@ -2703,7 +2765,13 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
   client-only@0.0.1: {}
+
+  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -3517,6 +3585,11 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  next-themes@0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   next@16.1.6(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.1.6
@@ -3899,6 +3972,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.1: {}
 


### PR DESCRIPTION
## Summary
- add theme-aware design tokens for light, dark, and system modes
- introduce minimal theme plumbing and a visible theme toggle
- apply the new typography, surface, spacing, and layout foundations to the existing scaffold

## Validation
- pnpm lint
- pnpm build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces client-side theme switching (`next-themes`) and rewires global styling to CSS variables, which can cause hydration/theme flash or broad visual regressions if tokens are off.
> 
> **Overview**
> Adds a **theme-aware design system foundation** by replacing the basic global styles with light/dark CSS variable tokens (colors, spacing, radius, shadows), updated base typography/selection/focus styling, and a `page-frame` layout utility.
> 
> Wires up **system/light/dark mode support** via a new `ThemeProvider` in `app/layout.tsx` (including new Google fonts) and a visible `ThemeToggle` control on the homepage, along with new UI primitives (`Button`, `cn` util) and shadcn `components.json` configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8465855c5eccde27cb52595d268acd919ad72f48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->