### PR TITLE
feat: add subtle homepage motion

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -96,6 +96,7 @@ body {
 
 main {
   position: relative;
+  isolation: isolate;
 }
 
 main::before {
@@ -109,6 +110,7 @@ main::before {
   content: "";
   mask-image: linear-gradient(180deg, rgb(0 0 0 / 0.22), transparent 74%);
   pointer-events: none;
+  z-index: 1;
 }
 
 h1,
@@ -129,6 +131,158 @@ p {
 
 .font-reading {
   font-family: var(--font-body), sans-serif;
+}
+
+.cursor-glow {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 0;
+  width: clamp(28rem, 42vw, 40rem);
+  aspect-ratio: 1;
+  border-radius: 999px;
+  background: radial-gradient(
+    circle,
+    color-mix(in oklab, var(--accent) 9%, transparent) 0%,
+    color-mix(in oklab, var(--accent) 5%, transparent) 30%,
+    transparent 74%
+  );
+  filter: blur(36px);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate3d(50vw, 22vh, 0) translate3d(-50%, -50%, 0);
+  transition: opacity 220ms ease;
+  will-change: transform, opacity;
+}
+
+.motion-reveal {
+  opacity: 0;
+  transform: translateY(12px);
+  animation: reveal-enter 640ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  will-change: transform, opacity;
+}
+
+.motion-reveal-figure {
+  animation-name: reveal-enter-figure;
+  transform: translateY(16px) scale(0.985);
+}
+
+.interactive-underline {
+  display: inline-block;
+  background-image: linear-gradient(currentColor, currentColor);
+  background-repeat: no-repeat;
+  background-position: left calc(100% - 0.08em);
+  background-size: 0 1px;
+  transition:
+    color 180ms ease,
+    background-size 220ms ease,
+    transform 180ms ease;
+}
+
+.interactive-underline:hover,
+.interactive-underline:focus-visible {
+  background-size: 100% 1px;
+  transform: translateY(-1px);
+}
+
+.contact-link {
+  transition:
+    color 180ms ease,
+    transform 220ms ease;
+}
+
+.contact-link:hover,
+.contact-link:focus-visible {
+  transform: translateX(1px);
+}
+
+.contact-link-icon {
+  transition:
+    color 180ms ease,
+    border-color 180ms ease,
+    transform 220ms ease;
+}
+
+.contact-link-value {
+  display: inline-block;
+  background-image: linear-gradient(currentColor, currentColor);
+  background-repeat: no-repeat;
+  background-position: left calc(100% - 0.08em);
+  background-size: 0 1px;
+  transition: background-size 220ms ease;
+}
+
+.contact-link:hover .contact-link-icon,
+.contact-link:focus-visible .contact-link-icon {
+  transform: translateY(-1px);
+}
+
+.contact-link:hover .contact-link-value,
+.contact-link:focus-visible .contact-link-value {
+  background-size: 100% 1px;
+}
+
+@keyframes reveal-enter {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes reveal-enter-figure {
+  from {
+    opacity: 0;
+    transform: translateY(16px) scale(0.985);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (pointer: coarse) {
+  .cursor-glow {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .cursor-glow {
+    display: none;
+  }
+
+  .motion-reveal,
+  .motion-reveal-figure {
+    opacity: 1;
+    transform: none;
+    animation: none;
+  }
+
+  .interactive-underline,
+  .contact-link,
+  .contact-link-icon,
+  .contact-link-value {
+    transition: none;
+  }
+
+  .interactive-underline:hover,
+  .interactive-underline:focus-visible,
+  .contact-link:hover,
+  .contact-link:focus-visible,
+  .contact-link:hover .contact-link-icon,
+  .contact-link:focus-visible .contact-link-icon {
+    transform: none;
+  }
 }
 
 @utility page-frame {

--- a/app/globals.css
+++ b/app/globals.css
@@ -167,22 +167,20 @@ p {
   transform: translateY(16px) scale(0.985);
 }
 
-.interactive-underline {
+.interactive-underline,
+.contact-link-value {
   display: inline-block;
   background-image: linear-gradient(currentColor, currentColor);
   background-repeat: no-repeat;
   background-position: left calc(100% - 0.08em);
   background-size: 0 1px;
+}
+
+.interactive-underline {
   transition:
     color 180ms ease,
     background-size 220ms ease,
     transform 180ms ease;
-}
-
-.interactive-underline:hover,
-.interactive-underline:focus-visible {
-  background-size: 100% 1px;
-  transform: translateY(-1px);
 }
 
 .contact-link {
@@ -204,11 +202,6 @@ p {
 }
 
 .contact-link-value {
-  display: inline-block;
-  background-image: linear-gradient(currentColor, currentColor);
-  background-repeat: no-repeat;
-  background-position: left calc(100% - 0.08em);
-  background-size: 0 1px;
   transition: background-size 220ms ease;
 }
 
@@ -217,9 +210,16 @@ p {
   transform: translateY(-1px);
 }
 
+.interactive-underline:hover,
+.interactive-underline:focus-visible,
 .contact-link:hover .contact-link-value,
 .contact-link:focus-visible .contact-link-value {
   background-size: 100% 1px;
+}
+
+.interactive-underline:hover,
+.interactive-underline:focus-visible {
+  transform: translateY(-1px);
 }
 
 @keyframes reveal-enter {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -152,10 +152,7 @@ export default function HomePage() {
   const currentYear = new Date().getFullYear();
 
   return (
-    <main
-      className="relative isolate min-h-screen overflow-hidden py-[var(--space-section)]"
-      id="top"
-    >
+    <main className="min-h-screen overflow-hidden py-[var(--space-section)]" id="top">
       <CursorGlow />
 
       <div className="page-frame relative z-10 space-y-16 sm:space-y-20 lg:space-y-24">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 
+import { CursorGlow } from "@/components/cursor-glow";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { siteConfig } from "@/lib/site";
 
@@ -151,15 +152,24 @@ export default function HomePage() {
   const currentYear = new Date().getFullYear();
 
   return (
-    <main className="min-h-screen py-[var(--space-section)]" id="top">
-      <div className="page-frame space-y-16 sm:space-y-20 lg:space-y-24">
+    <main
+      className="relative isolate min-h-screen overflow-hidden py-[var(--space-section)]"
+      id="top"
+    >
+      <CursorGlow />
+
+      <div className="page-frame relative z-10 space-y-16 sm:space-y-20 lg:space-y-24">
         <header className="flex items-center justify-between gap-6">
-          <nav aria-label="Primary">
+          <nav
+            aria-label="Primary"
+            className="motion-reveal"
+            style={{ animationDelay: "40ms" }}
+          >
             <ul className="flex flex-wrap items-center gap-x-6 gap-y-2">
               {navigationItems.map((item) => (
                 <li key={item.href}>
                   <a
-                    className="font-mono text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground transition-colors hover:text-foreground"
+                    className="interactive-underline font-mono text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground transition-colors hover:text-foreground"
                     href={item.href}
                   >
                     {item.label}
@@ -169,161 +179,179 @@ export default function HomePage() {
             </ul>
           </nav>
 
-          <ThemeToggle />
+          <div
+            className="motion-reveal"
+            style={{ animationDelay: "90ms" }}
+          >
+            <ThemeToggle />
+          </div>
         </header>
 
-          <section
-            aria-labelledby="home-heading"
-            className="grid gap-10 md:grid-cols-[minmax(0,1fr)_minmax(15rem,19rem)] md:items-center md:gap-12 lg:gap-16"
-          >
-            <div className="space-y-7">
-              <div className="space-y-4">
-                <p className="font-mono text-[0.68rem] uppercase tracking-[0.18em] text-accent">
-                  Piotr Harmasz
-                </p>
-
-                <div className="space-y-2">
-                  <h1
-                    className="max-w-[13ch] text-[clamp(2.3rem,1.85rem+1.9vw,3.8rem)] font-semibold leading-[1.04] tracking-[-0.05em] text-foreground"
-                    id="home-heading"
-                  >
-                    Product Lead with a full-stack builder mindset.
-                  </h1>
-                </div>
-
-                <p className="font-reading max-w-2xl text-[length:var(--text-lede)] leading-[1.9] text-muted-foreground">
-                  I work across product thinking, systems, and implementation.
-                  This rebuild is a quieter front page for selected work,
-                  previous experience, and whatever deserves more space next.
-                </p>
-              </div>
-
-              <div className="flex flex-wrap items-center gap-x-6 gap-y-3 border-t border-border pt-5">
-                {heroMeta.map((item) => (
-                  <div className="flex items-center gap-2.5" key={item.label}>
-                    <span className="font-mono text-[0.62rem] uppercase tracking-[0.16em] text-muted-foreground">
-                      {item.label}
-                    </span>
-                    <span className="font-reading text-sm leading-6 text-foreground sm:text-base">
-                      {item.value}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            <figure className="mx-auto w-full max-w-[17rem] md:mx-0 md:justify-self-end lg:max-w-[18.5rem]">
-              <div className="relative aspect-[4/5] overflow-hidden rounded-[1.75rem] bg-surface-strong shadow-[var(--shadow-panel)]">
-                <Image
-                  alt="Piotr Harmasz speaking at a podium"
-                  className="object-cover object-[50%_24%]"
-                  fill
-                  priority
-                  sizes="(min-width: 1024px) 18.5rem, (min-width: 768px) 15rem, 72vw"
-                  src="/profile/me-hero.jpg"
-                />
-                <div className="absolute inset-0 bg-linear-to-t from-background/28 via-transparent to-transparent" />
-                <div className="absolute inset-0 ring-1 ring-border/55 ring-inset" />
-              </div>
-            </figure>
-          </section>
-
-          <section
-            aria-labelledby="work-heading"
-            className="scroll-mt-24 space-y-8 border-t border-border pt-12 sm:space-y-10 sm:pt-14"
-            id="work"
-          >
-            <SectionHeading
-              description="Previous experience organized as the kinds of work I tend to move between: product direction, shipping software, and smaller experiments that sharpen both."
-              eyebrow="Work"
-              id="work-heading"
-              title="Previous experience across product, engineering, and the space between."
-            />
-
-            <div className="divide-y divide-border/90 border-t border-border/90">
-              {experienceItems.map((item) => (
-                <ExperienceRow item={item} key={`${item.role}-${item.organization}`} />
-              ))}
-            </div>
-          </section>
-
-          <section
-            aria-labelledby="about-heading"
-            className="scroll-mt-24 space-y-8 border-t border-border pt-12 sm:space-y-10 sm:pt-14"
-            id="about"
-          >
-            <SectionHeading
-              description="A short note on what the site is for and how the work tends to connect."
-              eyebrow="About"
-              id="about-heading"
-              title="I care about product judgment that stays close to the build."
-            />
-
-            <div className="max-w-3xl space-y-5">
-              <p className="font-reading text-sm leading-8 text-muted-foreground sm:text-base">
-                The work I tend to enjoy sits at the point where product
-                thinking, interface quality, and implementation detail start to
-                reinforce each other. Strategy matters, but so does knowing what
-                the thing actually becomes once it is built.
+        <section
+          aria-labelledby="home-heading"
+          className="grid gap-10 md:grid-cols-[minmax(0,1fr)_minmax(15rem,19rem)] md:items-center md:gap-12 lg:gap-16"
+        >
+          <div className="space-y-7">
+            <div className="space-y-4">
+              <p
+                className="motion-reveal font-mono text-[0.68rem] uppercase tracking-[0.18em] text-accent"
+                style={{ animationDelay: "130ms" }}
+              >
+                Piotr Harmasz
               </p>
 
-              <p className="font-reading text-sm leading-8 text-muted-foreground sm:text-base">
-                This site is being rebuilt from that perspective: minimal,
-                practical, and structured enough to evolve without turning into
-                a polished template before the content earns it.
-              </p>
-            </div>
-          </section>
-
-          <section
-            aria-labelledby="contact-heading"
-            className="scroll-mt-24 space-y-8 border-t border-border pt-12 sm:space-y-10 sm:pt-14"
-            id="contact"
-          >
-            <SectionHeading
-              description="The easiest ways to get in touch or find the rest of my work online."
-              eyebrow="Contact"
-              id="contact-heading"
-              title="Reach out where it makes the most sense."
-            />
-
-            <div className="max-w-2xl divide-y divide-border/90 border-t border-border/90">
-              {contactItems.map((item) => (
-                <a
-                  className="group flex items-start gap-4 py-5 text-muted-foreground transition-colors hover:text-foreground"
-                  href={item.href}
-                  key={item.label}
-                  rel={item.href.startsWith("http") ? "noreferrer" : undefined}
-                  target={item.href.startsWith("http") ? "_blank" : undefined}
+              <div className="space-y-2">
+                <h1
+                  className="motion-reveal max-w-[13ch] text-[clamp(2.3rem,1.85rem+1.9vw,3.8rem)] font-semibold leading-[1.04] tracking-[-0.05em] text-foreground"
+                  id="home-heading"
+                  style={{ animationDelay: "180ms" }}
                 >
-                  <span className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-border bg-surface text-muted-foreground transition-colors group-hover:border-foreground/20 group-hover:text-foreground">
-                    <item.icon aria-hidden="true" className="h-4 w-4" />
+                  Product Lead with a full-stack builder mindset.
+                </h1>
+              </div>
+
+              <p
+                className="motion-reveal font-reading max-w-2xl text-[length:var(--text-lede)] leading-[1.9] text-muted-foreground"
+                style={{ animationDelay: "240ms" }}
+              >
+                I work across product thinking, systems, and implementation.
+                This rebuild is a quieter front page for selected work,
+                previous experience, and whatever deserves more space next.
+              </p>
+            </div>
+
+            <div
+              className="motion-reveal flex flex-wrap items-center gap-x-6 gap-y-3 border-t border-border pt-5"
+              style={{ animationDelay: "300ms" }}
+            >
+              {heroMeta.map((item) => (
+                <div className="flex items-center gap-2.5" key={item.label}>
+                  <span className="font-mono text-[0.62rem] uppercase tracking-[0.16em] text-muted-foreground">
+                    {item.label}
                   </span>
-                  <span className="space-y-1">
-                    <span className="font-mono text-[0.66rem] uppercase tracking-[0.16em] text-muted-foreground">
-                      {item.label}
-                    </span>
-                    <span className="block font-reading text-sm leading-7 text-foreground sm:text-base">
-                      {item.value}
-                    </span>
+                  <span className="font-reading text-sm leading-6 text-foreground sm:text-base">
+                    {item.value}
                   </span>
-                </a>
+                </div>
               ))}
             </div>
-          </section>
+          </div>
 
-          <footer className="flex flex-col gap-4 border-t border-border pt-8 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
-            <p className="font-reading">
-              &copy; {currentYear} {siteConfig.name}. Personal site rebuild in
-              progress.
+          <figure
+            className="motion-reveal motion-reveal-figure mx-auto w-full max-w-[17rem] md:mx-0 md:justify-self-end lg:max-w-[18.5rem]"
+            style={{ animationDelay: "220ms" }}
+          >
+            <div className="relative aspect-[4/5] overflow-hidden rounded-[1.75rem] bg-surface-strong shadow-[var(--shadow-panel)]">
+              <Image
+                alt="Piotr Harmasz speaking at a podium"
+                className="object-cover object-[50%_24%]"
+                fill
+                priority
+                sizes="(min-width: 1024px) 18.5rem, (min-width: 768px) 15rem, 72vw"
+                src="/profile/me-hero.jpg"
+              />
+              <div className="absolute inset-0 bg-linear-to-t from-background/28 via-transparent to-transparent" />
+              <div className="absolute inset-0 ring-1 ring-border/55 ring-inset" />
+            </div>
+          </figure>
+        </section>
+
+        <section
+          aria-labelledby="work-heading"
+          className="scroll-mt-24 space-y-8 border-t border-border pt-12 sm:space-y-10 sm:pt-14"
+          id="work"
+        >
+          <SectionHeading
+            description="Previous experience organized as the kinds of work I tend to move between: product direction, shipping software, and smaller experiments that sharpen both."
+            eyebrow="Work"
+            id="work-heading"
+            title="Previous experience across product, engineering, and the space between."
+          />
+
+          <div className="divide-y divide-border/90 border-t border-border/90">
+            {experienceItems.map((item) => (
+              <ExperienceRow item={item} key={`${item.role}-${item.organization}`} />
+            ))}
+          </div>
+        </section>
+
+        <section
+          aria-labelledby="about-heading"
+          className="scroll-mt-24 space-y-8 border-t border-border pt-12 sm:space-y-10 sm:pt-14"
+          id="about"
+        >
+          <SectionHeading
+            description="A short note on what the site is for and how the work tends to connect."
+            eyebrow="About"
+            id="about-heading"
+            title="I care about product judgment that stays close to the build."
+          />
+
+          <div className="max-w-3xl space-y-5">
+            <p className="font-reading text-sm leading-8 text-muted-foreground sm:text-base">
+              The work I tend to enjoy sits at the point where product
+              thinking, interface quality, and implementation detail start to
+              reinforce each other. Strategy matters, but so does knowing what
+              the thing actually becomes once it is built.
             </p>
-            <a
-              className="font-mono text-[0.68rem] uppercase tracking-[0.14em] transition-colors hover:text-foreground"
-              href="#top"
-            >
-              Return to top
-            </a>
-          </footer>
+
+            <p className="font-reading text-sm leading-8 text-muted-foreground sm:text-base">
+              This site is being rebuilt from that perspective: minimal,
+              practical, and structured enough to evolve without turning into a
+              polished template before the content earns it.
+            </p>
+          </div>
+        </section>
+
+        <section
+          aria-labelledby="contact-heading"
+          className="scroll-mt-24 space-y-8 border-t border-border pt-12 sm:space-y-10 sm:pt-14"
+          id="contact"
+        >
+          <SectionHeading
+            description="The easiest ways to get in touch or find the rest of my work online."
+            eyebrow="Contact"
+            id="contact-heading"
+            title="Reach out where it makes the most sense."
+          />
+
+          <div className="max-w-2xl divide-y divide-border/90 border-t border-border/90">
+            {contactItems.map((item) => (
+              <a
+                className="contact-link group flex items-start gap-4 py-5 text-muted-foreground transition-colors hover:text-foreground"
+                href={item.href}
+                key={item.label}
+                rel={item.href.startsWith("http") ? "noreferrer" : undefined}
+                target={item.href.startsWith("http") ? "_blank" : undefined}
+              >
+                <span className="contact-link-icon mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-border bg-surface text-muted-foreground transition-colors group-hover:border-foreground/20 group-hover:text-foreground">
+                  <item.icon aria-hidden="true" className="h-4 w-4" />
+                </span>
+                <span className="flex min-w-0 flex-col gap-1">
+                  <span className="block font-mono text-[0.66rem] uppercase tracking-[0.16em] text-muted-foreground">
+                    {item.label}
+                  </span>
+                  <span className="contact-link-value font-reading text-sm leading-7 text-foreground sm:text-base">
+                    {item.value}
+                  </span>
+                </span>
+              </a>
+            ))}
+          </div>
+        </section>
+
+        <footer className="flex flex-col gap-4 border-t border-border pt-8 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+          <p className="font-reading">
+            &copy; {currentYear} {siteConfig.name}. Personal site rebuild in
+            progress.
+          </p>
+          <a
+            className="interactive-underline font-mono text-[0.68rem] uppercase tracking-[0.14em] transition-colors hover:text-foreground"
+            href="#top"
+          >
+            Return to top
+          </a>
+        </footer>
       </div>
     </main>
   );

--- a/components/cursor-glow.tsx
+++ b/components/cursor-glow.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+function getRestingPosition() {
+  return {
+    x: window.innerWidth * 0.62,
+    y: window.innerHeight * 0.24,
+  };
+}
+
+export function CursorGlow() {
+  const glowRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const glow = glowRef.current;
+
+    if (!glow) {
+      return;
+    }
+
+    const pointerMedia = window.matchMedia("(pointer: fine)");
+    const reducedMotionMedia = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    );
+
+    let frameId = 0;
+    let removeListeners: (() => void) | null = null;
+
+    const stop = () => {
+      if (frameId !== 0) {
+        window.cancelAnimationFrame(frameId);
+        frameId = 0;
+      }
+
+      removeListeners?.();
+      removeListeners = null;
+      glow.style.removeProperty("opacity");
+      glow.style.removeProperty("transform");
+    };
+
+    const start = () => {
+      if (!pointerMedia.matches || reducedMotionMedia.matches || removeListeners) {
+        return;
+      }
+
+      const restingPosition = getRestingPosition();
+      let targetX = restingPosition.x;
+      let targetY = restingPosition.y;
+      let currentX = restingPosition.x;
+      let currentY = restingPosition.y;
+
+      const render = () => {
+        currentX += (targetX - currentX) * 0.08;
+        currentY += (targetY - currentY) * 0.08;
+
+        glow.style.opacity = "1";
+        glow.style.transform = `translate3d(${currentX}px, ${currentY}px, 0) translate3d(-50%, -50%, 0)`;
+
+        frameId = window.requestAnimationFrame(render);
+      };
+
+      const handlePointerMove = (event: PointerEvent) => {
+        if (
+          event.pointerType &&
+          event.pointerType !== "mouse" &&
+          event.pointerType !== "pen"
+        ) {
+          return;
+        }
+
+        targetX = event.clientX;
+        targetY = event.clientY;
+      };
+
+      const handleReset = () => {
+        const nextRestingPosition = getRestingPosition();
+
+        targetX = nextRestingPosition.x;
+        targetY = nextRestingPosition.y;
+      };
+
+      window.addEventListener("pointermove", handlePointerMove, {
+        passive: true,
+      });
+      window.addEventListener("blur", handleReset);
+      window.addEventListener("resize", handleReset, { passive: true });
+
+      removeListeners = () => {
+        window.removeEventListener("pointermove", handlePointerMove);
+        window.removeEventListener("blur", handleReset);
+        window.removeEventListener("resize", handleReset);
+      };
+
+      render();
+    };
+
+    const sync = () => {
+      stop();
+
+      if (pointerMedia.matches && !reducedMotionMedia.matches) {
+        start();
+      }
+    };
+
+    sync();
+    pointerMedia.addEventListener("change", sync);
+    reducedMotionMedia.addEventListener("change", sync);
+
+    return () => {
+      stop();
+      pointerMedia.removeEventListener("change", sync);
+      reducedMotionMedia.removeEventListener("change", sync);
+    };
+  }, []);
+
+  return <div aria-hidden="true" className="cursor-glow" ref={glowRef} />;
+}

--- a/components/cursor-glow.tsx
+++ b/components/cursor-glow.tsx
@@ -49,13 +49,32 @@ export function CursorGlow() {
       let targetY = restingPosition.y;
       let currentX = restingPosition.x;
       let currentY = restingPosition.y;
-
-      const render = () => {
-        currentX += (targetX - currentX) * 0.08;
-        currentY += (targetY - currentY) * 0.08;
-
+      const applyPosition = () => {
         glow.style.opacity = "1";
         glow.style.transform = `translate3d(${currentX}px, ${currentY}px, 0) translate3d(-50%, -50%, 0)`;
+      };
+
+      const ensureAnimation = () => {
+        if (frameId === 0) {
+          frameId = window.requestAnimationFrame(render);
+        }
+      };
+
+      const render = () => {
+        const deltaX = targetX - currentX;
+        const deltaY = targetY - currentY;
+
+        if (Math.abs(deltaX) < 0.1 && Math.abs(deltaY) < 0.1) {
+          currentX = targetX;
+          currentY = targetY;
+          applyPosition();
+          frameId = 0;
+          return;
+        }
+
+        currentX += deltaX * 0.08;
+        currentY += deltaY * 0.08;
+        applyPosition();
 
         frameId = window.requestAnimationFrame(render);
       };
@@ -71,6 +90,7 @@ export function CursorGlow() {
 
         targetX = event.clientX;
         targetY = event.clientY;
+        ensureAnimation();
       };
 
       const handleReset = () => {
@@ -78,7 +98,10 @@ export function CursorGlow() {
 
         targetX = nextRestingPosition.x;
         targetY = nextRestingPosition.y;
+        ensureAnimation();
       };
+
+      applyPosition();
 
       window.addEventListener("pointermove", handlePointerMove, {
         passive: true,
@@ -91,8 +114,6 @@ export function CursorGlow() {
         window.removeEventListener("blur", handleReset);
         window.removeEventListener("resize", handleReset);
       };
-
-      render();
     };
 
     const sync = () => {

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useSyncExternalStore } from "react";
 import { useTheme } from "next-themes";
 
 import { Button } from "@/components/ui/button";
@@ -11,12 +12,20 @@ const themeOptions = [
   { label: "Dark", value: "dark" },
 ] as const;
 
+const emptySubscribe = () => () => {};
+
 export function ThemeToggle() {
   const { setTheme, theme } = useTheme();
-  const activeTheme = theme ?? "system";
+  const mounted = useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false,
+  );
+
+  const activeTheme = mounted ? (theme ?? "system") : null;
 
   return (
-    <div className="inline-flex items-center gap-2 rounded-full bg-surface/90 p-1 shadow-[var(--shadow-soft)]">
+    <div className="inline-flex items-center gap-2 rounded-full border border-border/55 bg-surface/48 p-1 shadow-[0_16px_34px_-30px_rgb(15_23_42_/_0.16)] backdrop-blur-[2px] dark:shadow-[0_18px_40px_-30px_rgb(2_6_23_/_0.48)]">
       <div
         aria-label="Theme switcher"
         className="inline-flex items-center gap-1"


### PR DESCRIPTION
## Summary
- add restrained page-load motion to the header and hero
- refine link and theme-toggle interaction states while keeping the UI minimal
- add a faint cursor-follow glow with touch and reduced-motion safeguards

## Testing
- pnpm lint
- pnpm build