### PR TITLE
chore: align repo identity with 0xf000h.dev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-This repository is a fresh rebuild of [0xf000h.dev](https://0xf000h.dev). Treat it as an intentionally new project, not a direct port of the previous site.
+This repository is the canonical source for [0xf000h.dev](https://0xf000h.dev). It replaced the previous site and should be treated as the current production codebase.
 
 ## Operating Principles
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# 0xf000h-v2
+# 0xf000h.dev
 
-Fresh rebuild of [0xf000h.dev](https://0xf000h.dev).
+Source for [0xf000h.dev](https://0xf000h.dev).
 
-This repository is the clean-slate v2 of the personal site. It replaces an older Next.js site previously deployed on Vercel, but it is intentionally not a direct port. The goal is to rebuild the site from first principles, with clearer structure, tighter scope, and better long-term maintainability.
+This repository contains the current personal site. It replaced the previous version and now serves as the canonical codebase for 0xf000h.dev, with an emphasis on clear structure, tight scope, and long-term maintainability.
 
 ## Goals
 
-- Rebuild the site deliberately instead of copying the previous implementation.
+- Continue improving the site deliberately instead of carrying forward legacy implementation choices.
 - Keep product, design, and branding decisions explicit and intentional.
 - Optimize for maintainable code, simple architecture, and small reviewable changes.
 - Prepare the project for deployment on Vercel without locking in the final stack too early.
@@ -29,7 +29,7 @@ This repository is the clean-slate v2 of the personal site. It replaces an older
 
 - Use conventional commits.
 - Use descriptive branch names such as `docs/*`, `feat/*`, and `chore/*`.
-- Keep the first PR small and reviewable.
+- Keep changes small and reviewable.
 
 ## Current Stack
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -395,8 +395,8 @@ export default function HomePage() {
 
         <footer className="flex flex-col gap-4 border-t border-border pt-8 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
           <p className="font-reading">
-            &copy; {currentYear} {siteConfig.name}. Personal site rebuild in
-            progress.
+            &copy; {currentYear} {siteConfig.name}. Personal site of Piotr
+            Harmasz.
           </p>
           <a
             className="interactive-underline font-mono text-[0.68rem] uppercase tracking-[0.14em] transition-colors hover:text-foreground"

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,5 +1,5 @@
 export const siteConfig = {
   name: "0xf000h.dev",
-  description: "Fresh rebuild of the personal site.",
+  description: "Personal site of Piotr Harmasz.",
   url: "https://0xf000h.dev",
 } as const;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "0xf000h-v2",
+  "name": "0xf000h.dev",
   "version": "0.1.0",
   "private": true,
   "packageManager": "pnpm@10.32.1",


### PR DESCRIPTION
## Summary
- rename the package from 0xf000h-v2 to 0xf000h.dev
- update repo documentation to describe this as the canonical production site
- remove transitional rebuild wording from site metadata and footer copy

## Testing
- not run (content and metadata changes only)