### PR TITLE
feat: improve mobile hero responsiveness

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import {
   Github,
   Linkedin,
   Mail,
+  Menu,
   Twitter,
   type LucideIcon,
 } from "lucide-react";
@@ -194,10 +195,41 @@ export default function HomePage() {
       <CursorGlow />
 
       <div className="page-frame relative z-10 space-y-16 sm:space-y-20 lg:space-y-24">
-        <header className="flex items-center justify-between gap-6">
+        <header className="flex items-start justify-between gap-6">
+          <details
+            className="motion-reveal group w-full md:hidden"
+            style={{ animationDelay: "40ms" }}
+          >
+            <summary className="flex w-fit list-none items-center gap-2 rounded-full border border-border/70 bg-surface/88 px-4 py-2.5 font-mono text-[0.68rem] uppercase tracking-[0.16em] text-muted-foreground shadow-[var(--shadow-soft)] marker:hidden">
+              <Menu className="size-4" strokeWidth={1.8} />
+              Menu
+            </summary>
+
+            <div className="mt-4 space-y-5 rounded-[1.5rem] border border-border bg-surface p-5 shadow-[var(--shadow-panel)]">
+              <nav aria-label="Primary">
+                <ul className="space-y-3">
+                  {navigationItems.map((item) => (
+                    <li key={item.href}>
+                      <a
+                        className="interactive-underline font-mono text-[0.72rem] uppercase tracking-[0.16em] text-muted-foreground transition-colors hover:text-foreground"
+                        href={item.href}
+                      >
+                        {item.label}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </nav>
+
+              <div>
+                <ThemeToggle />
+              </div>
+            </div>
+          </details>
+
           <nav
             aria-label="Primary"
-            className="motion-reveal"
+            className="motion-reveal hidden md:block"
             style={{ animationDelay: "40ms" }}
           >
             <ul className="flex flex-wrap items-center gap-x-6 gap-y-2">
@@ -215,7 +247,7 @@ export default function HomePage() {
           </nav>
 
           <div
-            className="motion-reveal"
+            className="motion-reveal hidden md:block"
             style={{ animationDelay: "90ms" }}
           >
             <ThemeToggle />
@@ -224,9 +256,9 @@ export default function HomePage() {
 
         <section
           aria-labelledby="home-heading"
-          className="grid gap-10 md:grid-cols-[minmax(0,1fr)_minmax(15rem,19rem)] md:items-center md:gap-12 lg:gap-16"
+          className="grid gap-8 md:grid-cols-[minmax(0,1fr)_minmax(15rem,19rem)] md:items-center md:gap-12 lg:gap-16"
         >
-          <div className="space-y-7">
+          <div className="order-2 space-y-7 md:order-1">
             <div className="space-y-4">
               <p
                 className="motion-reveal font-mono text-[0.68rem] uppercase tracking-[0.18em] text-accent"
@@ -273,7 +305,7 @@ export default function HomePage() {
           </div>
 
           <figure
-            className="motion-reveal motion-reveal-figure mx-auto w-full max-w-[17rem] md:mx-0 md:justify-self-end lg:max-w-[18.5rem]"
+            className="motion-reveal motion-reveal-figure order-1 w-full max-w-[min(78vw,15rem)] md:order-2 md:mx-0 md:justify-self-end md:max-w-[17rem] lg:max-w-[18.5rem]"
             style={{ animationDelay: "220ms" }}
           >
             <div className="relative aspect-[4/5] overflow-hidden rounded-[1.75rem] bg-surface-strong shadow-[var(--shadow-panel)]">


### PR DESCRIPTION
## Summary
- move the hero image above the copy on mobile and reduce its footprint
- left-align the mobile hero image while preserving desktop placement
- replace the cramped mobile header with a compact menu panel that includes navigation and theme controls

## Testing
- pnpm lint