### PR TITLE
chore: ignore generated next-env declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ yarn-error.log*
 .vercel
 
 # typescript
+next-env.d.ts
 *.tsbuildinfo

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- ignore generated `next-env.d.ts` in git
- stop tracking the generated file to avoid dev/build route-type churn in diffs
- preserve current Next.js behavior while removing validation noise

## Validation
- pnpm lint
- pnpm build