### PR TITLE
feat: add social metadata and OG image

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,12 +19,54 @@ const monoFont = Geist_Mono({
 });
 
 export const metadata: Metadata = {
+	applicationName: siteConfig.name,
 	title: {
-		default: siteConfig.name,
-		template: `%s | ${siteConfig.name}`,
+		default: `${siteConfig.author} | ${siteConfig.role}`,
+		template: `%s | ${siteConfig.author}`,
 	},
 	description: siteConfig.description,
+	authors: [
+		{
+			name: siteConfig.author,
+			url: siteConfig.url,
+		},
+	],
+	creator: siteConfig.author,
+	publisher: siteConfig.author,
+	keywords: [...siteConfig.keywords],
 	metadataBase: new URL(siteConfig.url),
+	alternates: {
+		canonical: "/",
+	},
+	openGraph: {
+		type: "website",
+		url: siteConfig.url,
+		title: `${siteConfig.author} | ${siteConfig.role}`,
+		description: siteConfig.description,
+		siteName: siteConfig.name,
+		locale: "en_US",
+		images: [
+			{
+				url: "/opengraph-image",
+				width: 1200,
+				height: 630,
+				alt: `${siteConfig.author} - ${siteConfig.role}`,
+			},
+		],
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: `${siteConfig.author} | ${siteConfig.role}`,
+		description: siteConfig.description,
+		creator: siteConfig.socials.xHandle,
+		images: [
+			{
+				url: "/opengraph-image",
+				alt: `${siteConfig.author} - ${siteConfig.role}`,
+			},
+		],
+	},
+	category: "technology",
 };
 
 type RootLayoutProps = Readonly<{

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,221 @@
+import { readFile } from "node:fs/promises";
+
+import { ImageResponse } from "next/og";
+
+import { siteConfig } from "@/lib/site";
+
+export const alt = `${siteConfig.author} - ${siteConfig.role}`;
+export const contentType = "image/png";
+export const runtime = "nodejs";
+export const size = {
+	width: 1200,
+	height: 630,
+};
+
+const portraitPath = new URL("../public/profile/me-hero.jpg", import.meta.url);
+
+export default async function OpenGraphImage() {
+	const portraitBuffer = await readFile(portraitPath);
+	const portraitSrc = `data:image/jpeg;base64,${portraitBuffer.toString("base64")}`;
+
+	return new ImageResponse(
+		<div
+			style={{
+				display: "flex",
+				height: "100%",
+				width: "100%",
+				position: "relative",
+				overflow: "hidden",
+				background:
+					"radial-gradient(circle at top left, rgba(59, 130, 246, 0.06) 0%, rgba(59, 130, 246, 0) 26%), linear-gradient(180deg, rgb(249, 250, 251) 0%, rgb(244, 247, 250) 100%)",
+				color: "rgb(15, 23, 42)",
+				fontFamily: "system-ui, sans-serif",
+			}}
+		>
+			<div
+				style={{
+					display: "flex",
+					flex: 1,
+					padding: "54px",
+					alignItems: "center",
+					justifyContent: "space-between",
+					gap: "64px",
+				}}
+			>
+				<div
+					style={{
+						display: "flex",
+						flex: "0 0 64%",
+						flexDirection: "column",
+						gap: "20px",
+					}}
+				>
+					<div
+						style={{
+							display: "flex",
+							fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+							fontSize: 13,
+							letterSpacing: "0.18em",
+							textTransform: "uppercase",
+							color: "rgb(59, 130, 246)",
+						}}
+					>
+						{siteConfig.author}
+					</div>
+
+					<div
+						style={{
+							display: "flex",
+							maxWidth: "560px",
+							fontSize: 56,
+							fontWeight: 600,
+							lineHeight: 1.04,
+							letterSpacing: "-0.055em",
+						}}
+					>
+						I help SaaS companies turn product clarity into growth.
+					</div>
+
+					<div
+						style={{
+							display: "flex",
+							maxWidth: "620px",
+							fontSize: 18,
+							lineHeight: 1.7,
+							color: "rgb(100, 116, 139)",
+						}}
+					>
+						I work across product leadership, systems, and implementation to
+						help teams make better bets, ship with more focus, and build
+						products that support real business outcomes.
+					</div>
+
+					<div
+						style={{
+							display: "flex",
+							flexDirection: "column",
+							gap: "16px",
+							paddingTop: "12px",
+						}}
+					>
+						<div
+							style={{
+								display: "flex",
+								width: "100%",
+								height: "1px",
+								background: "rgba(203, 213, 225, 0.95)",
+							}}
+						/>
+
+						<div
+							style={{
+								display: "flex",
+								alignItems: "center",
+								gap: "30px",
+								fontSize: 14,
+							}}
+						>
+							<div
+								style={{
+									display: "flex",
+									alignItems: "center",
+									gap: "10px",
+								}}
+							>
+								<span
+									style={{
+										display: "flex",
+										fontFamily:
+											"ui-monospace, SFMono-Regular, Menlo, monospace",
+										fontSize: 11,
+										letterSpacing: "0.16em",
+										textTransform: "uppercase",
+										color: "rgb(100, 116, 139)",
+									}}
+								>
+									Role
+								</span>
+								<span
+									style={{
+										display: "flex",
+										fontSize: 15,
+										color: "rgb(15, 23, 42)",
+									}}
+								>
+									{siteConfig.role}
+								</span>
+							</div>
+
+							<div
+								style={{
+									display: "flex",
+									alignItems: "center",
+									gap: "10px",
+								}}
+							>
+								<span
+									style={{
+										display: "flex",
+										fontFamily:
+											"ui-monospace, SFMono-Regular, Menlo, monospace",
+										fontSize: 11,
+										letterSpacing: "0.16em",
+										textTransform: "uppercase",
+										color: "rgb(100, 116, 139)",
+									}}
+								>
+									Base
+								</span>
+								<span
+									style={{
+										display: "flex",
+										fontSize: 15,
+										color: "rgb(15, 23, 42)",
+									}}
+								>
+									{siteConfig.location}
+								</span>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<div
+					style={{
+						display: "flex",
+						flex: "0 0 auto",
+						alignItems: "center",
+						justifyContent: "center",
+					}}
+				>
+					<div
+						style={{
+							display: "flex",
+							width: "240px",
+							height: "300px",
+							overflow: "hidden",
+							borderRadius: "28px",
+							background: "rgb(226, 232, 240)",
+							boxShadow: "0 20px 50px -36px rgba(15, 23, 42, 0.28)",
+						}}
+					>
+						{/* biome-ignore lint/performance/noImgElement: next/og image routes render standard img elements. */}
+						<img
+							alt={alt}
+							src={portraitSrc}
+							style={{
+								display: "flex",
+								height: "100%",
+								width: "100%",
+								borderRadius: "28px",
+								objectFit: "cover",
+								objectPosition: "50% 24%",
+							}}
+						/>
+					</div>
+				</div>
+			</div>
+		</div>,
+		size,
+	);
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -52,32 +52,32 @@ const contactItems: ReadonlyArray<ContactItem> = [
 	{
 		icon: Github,
 		label: "GitHub",
-		href: "https://github.com/harmasz",
+		href: siteConfig.socials.github,
 		value: "harmasz",
 	},
 	{
 		icon: Linkedin,
 		label: "LinkedIn",
-		href: "https://www.linkedin.com/in/piotr-harmasz/",
+		href: siteConfig.socials.linkedin,
 		value: "piotr-harmasz",
 	},
 	{
 		icon: Twitter,
 		label: "X",
-		href: "https://x.com/phrm0",
-		value: "@phrm0",
+		href: siteConfig.socials.x,
+		value: siteConfig.socials.xHandle,
 	},
 	{
 		icon: Mail,
 		label: "Email",
-		href: "mailto:0xf000h@gmail.com",
-		value: "0xf000h@gmail.com",
+		href: `mailto:${siteConfig.email}`,
+		value: siteConfig.email,
 	},
 ];
 
 const heroMeta: ReadonlyArray<HeroMetaItem> = [
-	{ label: "Role", value: "Product Lead / Builder" },
-	{ label: "Base", value: "Wrocław, Poland" },
+	{ label: "Role", value: siteConfig.role },
+	{ label: "Base", value: siteConfig.location },
 ];
 
 const helpItems: ReadonlyArray<HelpItem> = [

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+
+import { siteConfig } from "@/lib/site";
+
+export default function robots(): MetadataRoute.Robots {
+	return {
+		rules: {
+			userAgent: "*",
+			allow: "/",
+		},
+		sitemap: `${siteConfig.url}/sitemap.xml`,
+		host: siteConfig.url,
+	};
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+
+import { siteConfig } from "@/lib/site";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+	return [
+		{
+			url: siteConfig.url,
+			lastModified: new Date(),
+			changeFrequency: "monthly",
+			priority: 1,
+		},
+	];
+}

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,5 +1,27 @@
 export const siteConfig = {
 	name: "0xf000h.dev",
-	description: "Personal site of Piotr Harmasz.",
+	title: "Piotr Harmasz",
+	description:
+		"Personal site of Piotr Harmasz, a product lead helping SaaS companies turn product clarity into growth.",
 	url: "https://0xf000h.dev",
+	author: "Piotr Harmasz",
+	role: "Product Lead / Builder",
+	location: "Wroclaw, Poland",
+	email: "0xf000h@gmail.com",
+	keywords: [
+		"Piotr Harmasz",
+		"0xf000h",
+		"product lead",
+		"product leadership",
+		"SaaS",
+		"growth",
+		"product strategy",
+		"product operations",
+	],
+	socials: {
+		github: "https://github.com/harmasz",
+		linkedin: "https://www.linkedin.com/in/piotr-harmasz/",
+		x: "https://x.com/phrm0",
+		xHandle: "@phrm0",
+	},
 } as const;

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,12 +1,11 @@
 export const siteConfig = {
 	name: "0xf000h.dev",
-	title: "Piotr Harmasz",
 	description:
 		"Personal site of Piotr Harmasz, a product lead helping SaaS companies turn product clarity into growth.",
 	url: "https://0xf000h.dev",
 	author: "Piotr Harmasz",
 	role: "Product Lead / Builder",
-	location: "Wroclaw, Poland",
+	location: "Wrocław, Poland",
 	email: "0xf000h@gmail.com",
 	keywords: [
 		"Piotr Harmasz",


### PR DESCRIPTION
## Summary
- add richer site metadata for search and social previews
- add generated Open Graph image, robots.txt, and sitemap routes
- centralize site metadata values used by the new routes

## Validation
- pnpm check
- pnpm build
