### PR TITLE
fix: render apostrophe in about copy

### DIFF
--- a/content/home.ts
+++ b/content/home.ts
@@ -180,7 +180,7 @@ export const homePageContent = {
 		},
 		paragraphs: [
 			"Companies rarely need more ideas. They need better judgment, clearer priorities, and tighter feedback loops between product decisions and what actually gets built.",
-			"That&apos;s the space I tend to operate in across product leadership, software, analytics, and AI, helping teams move faster without losing depth, and scale without losing focus.",
+			"That's the space I tend to operate in across product leadership, software, analytics, and AI, helping teams move faster without losing depth, and scale without losing focus.",
 		],
 	},
 	contact: {


### PR DESCRIPTION
## Summary

- Replaces the escaped HTML entity in the About section copy with a plain apostrophe so the page renders the intended text.

## Root cause

The copy lives in a JavaScript string rendered by React, so `&apos;` was treated as literal text instead of HTML.

## Validation

- `pnpm check`
- `pnpm build`