### PR TITLE
chore: update typescript and lucide

### DIFF
--- a/components/home/contact-section.tsx
+++ b/components/home/contact-section.tsx
@@ -1,4 +1,5 @@
-import { Github, Linkedin, type LucideIcon, Mail, Twitter } from "lucide-react";
+import { Mail } from "lucide-react";
+import type { ComponentType, SVGProps } from "react";
 import { SectionHeading } from "@/components/home/section-heading";
 import type {
 	ContactItem,
@@ -10,10 +11,36 @@ type ContactSectionProps = Readonly<{
 	section: ContactSectionContent;
 }>;
 
-const contactIcons: Record<ContactKind, LucideIcon> = {
-	github: Github,
-	linkedin: Linkedin,
-	x: Twitter,
+type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
+
+function GitHubIcon(props: SVGProps<SVGSVGElement>) {
+	return (
+		<svg aria-hidden="true" fill="currentColor" viewBox="0 0 24 24" {...props}>
+			<path d="M12 2C6.48 2 2 6.58 2 12.26c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.5 0-.24-.01-.88-.01-1.73-2.78.62-3.37-1.37-3.37-1.37-.45-1.19-1.11-1.5-1.11-1.5-.91-.64.07-.63.07-.63 1 .07 1.53 1.06 1.53 1.06.9 1.57 2.35 1.12 2.92.85.09-.66.35-1.12.63-1.37-2.22-.26-4.55-1.14-4.55-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.31.1-2.72 0 0 .84-.28 2.75 1.05A9.42 9.42 0 0 1 12 6.96c.85 0 1.7.12 2.5.35 1.9-1.33 2.74-1.05 2.74-1.05.55 1.41.2 2.46.1 2.72.64.72 1.03 1.63 1.03 2.75 0 3.94-2.34 4.81-4.57 5.07.36.32.68.94.68 1.9 0 1.37-.01 2.47-.01 2.8 0 .28.18.6.69.5A10.23 10.23 0 0 0 22 12.26C22 6.58 17.52 2 12 2Z" />
+		</svg>
+	);
+}
+
+function LinkedInIcon(props: SVGProps<SVGSVGElement>) {
+	return (
+		<svg aria-hidden="true" fill="currentColor" viewBox="0 0 24 24" {...props}>
+			<path d="M6.94 8.87H3.73V20h3.21V8.87ZM5.33 4a1.86 1.86 0 1 0 0 3.72A1.86 1.86 0 0 0 5.33 4Zm15.16 9.9c0-3.28-1.75-4.8-4.08-4.8a3.53 3.53 0 0 0-3.18 1.75h-.04V8.87h-3.08V20h3.2v-5.5c0-1.45.27-2.86 2.07-2.86 1.77 0 1.79 1.67 1.79 2.95V20h3.21l.11-6.1Z" />
+		</svg>
+	);
+}
+
+function XBrandIcon(props: SVGProps<SVGSVGElement>) {
+	return (
+		<svg aria-hidden="true" fill="currentColor" viewBox="0 0 24 24" {...props}>
+			<path d="M13.86 10.47 21.15 2h-1.73l-6.33 7.35L8.04 2H2.21l7.65 11.12L2.21 22h1.73l6.69-7.76L15.96 22h5.83l-7.93-11.53Zm-2.37 2.75-.78-1.1L4.56 3.3h2.65l4.97 7.11.77 1.1 6.47 9.26h-2.65l-5.28-7.56Z" />
+		</svg>
+	);
+}
+
+const contactIcons: Record<ContactKind, IconComponent> = {
+	github: GitHubIcon,
+	linkedin: LinkedInIcon,
+	x: XBrandIcon,
 	email: Mail,
 };
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"@vercel/speed-insights": "^2.0.0",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
-		"lucide-react": "^0.577.0",
+		"lucide-react": "^1.16.0",
 		"next": "^16.2.6",
 		"next-themes": "^0.4.6",
 		"react": "^19.2.6",
@@ -37,6 +37,6 @@
 		"@types/react-dom": "^19.2.3",
 		"postcss": "^8.5.14",
 		"tailwindcss": "^4.3.0",
-		"typescript": "^5.9.3"
+		"typescript": "^6.0.3"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       lucide-react:
-        specifier: ^0.577.0
-        version: 0.577.0(react@19.2.6)
+        specifier: ^1.16.0
+        version: 1.16.0(react@19.2.6)
       next:
         specifier: ^16.2.6
         version: 16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -67,8 +67,8 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
 packages:
 
@@ -649,8 +649,8 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
-  lucide-react@0.577.0:
-    resolution: {integrity: sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==}
+  lucide-react@1.16.0:
+    resolution: {integrity: sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -747,8 +747,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1123,7 +1123,7 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
-  lucide-react@0.577.0(react@19.2.6):
+  lucide-react@1.16.0(react@19.2.6):
     dependencies:
       react: 19.2.6
 
@@ -1229,6 +1229,6 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   undici-types@7.24.6: {}


### PR DESCRIPTION
## Summary

Updates the higher-risk dependency pair separately from the routine minor/patch updates in #23.

Updated packages:
- typescript 5.9.3 -> 6.0.3
- lucide-react 0.577.0 -> 1.16.0

## Notes

lucide-react 1.x no longer exports the brand icons previously used for GitHub, LinkedIn, and X. This PR replaces those three contact icons with local decorative SVG components and keeps lucide-react for the email icon.

This PR is stacked on #23 so the diff only shows the TypeScript/lucide-specific changes.

## Validation

- pnpm check
- pnpm build
- pnpm audit --audit-level moderate