### PR TITLE
chore: replace lucide with local icons

### DIFF
--- a/components/home/contact-section.tsx
+++ b/components/home/contact-section.tsx
@@ -1,6 +1,11 @@
-import { Mail } from "lucide-react";
 import type { ComponentType, SVGProps } from "react";
 import { SectionHeading } from "@/components/home/section-heading";
+import {
+	GitHubIcon,
+	LinkedInIcon,
+	MailIcon,
+	XIcon,
+} from "@/components/ui/icons";
 import type {
 	ContactItem,
 	ContactKind,
@@ -13,35 +18,11 @@ type ContactSectionProps = Readonly<{
 
 type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
 
-function GitHubIcon(props: SVGProps<SVGSVGElement>) {
-	return (
-		<svg aria-hidden="true" fill="currentColor" viewBox="0 0 24 24" {...props}>
-			<path d="M12 2C6.48 2 2 6.58 2 12.26c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.5 0-.24-.01-.88-.01-1.73-2.78.62-3.37-1.37-3.37-1.37-.45-1.19-1.11-1.5-1.11-1.5-.91-.64.07-.63.07-.63 1 .07 1.53 1.06 1.53 1.06.9 1.57 2.35 1.12 2.92.85.09-.66.35-1.12.63-1.37-2.22-.26-4.55-1.14-4.55-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.31.1-2.72 0 0 .84-.28 2.75 1.05A9.42 9.42 0 0 1 12 6.96c.85 0 1.7.12 2.5.35 1.9-1.33 2.74-1.05 2.74-1.05.55 1.41.2 2.46.1 2.72.64.72 1.03 1.63 1.03 2.75 0 3.94-2.34 4.81-4.57 5.07.36.32.68.94.68 1.9 0 1.37-.01 2.47-.01 2.8 0 .28.18.6.69.5A10.23 10.23 0 0 0 22 12.26C22 6.58 17.52 2 12 2Z" />
-		</svg>
-	);
-}
-
-function LinkedInIcon(props: SVGProps<SVGSVGElement>) {
-	return (
-		<svg aria-hidden="true" fill="currentColor" viewBox="0 0 24 24" {...props}>
-			<path d="M6.94 8.87H3.73V20h3.21V8.87ZM5.33 4a1.86 1.86 0 1 0 0 3.72A1.86 1.86 0 0 0 5.33 4Zm15.16 9.9c0-3.28-1.75-4.8-4.08-4.8a3.53 3.53 0 0 0-3.18 1.75h-.04V8.87h-3.08V20h3.2v-5.5c0-1.45.27-2.86 2.07-2.86 1.77 0 1.79 1.67 1.79 2.95V20h3.21l.11-6.1Z" />
-		</svg>
-	);
-}
-
-function XBrandIcon(props: SVGProps<SVGSVGElement>) {
-	return (
-		<svg aria-hidden="true" fill="currentColor" viewBox="0 0 24 24" {...props}>
-			<path d="M13.86 10.47 21.15 2h-1.73l-6.33 7.35L8.04 2H2.21l7.65 11.12L2.21 22h1.73l6.69-7.76L15.96 22h5.83l-7.93-11.53Zm-2.37 2.75-.78-1.1L4.56 3.3h2.65l4.97 7.11.77 1.1 6.47 9.26h-2.65l-5.28-7.56Z" />
-		</svg>
-	);
-}
-
 const contactIcons: Record<ContactKind, IconComponent> = {
 	github: GitHubIcon,
 	linkedin: LinkedInIcon,
-	x: XBrandIcon,
-	email: Mail,
+	x: XIcon,
+	email: MailIcon,
 };
 
 function ContactLink({ item }: Readonly<{ item: ContactItem }>) {

--- a/components/home/site-header.tsx
+++ b/components/home/site-header.tsx
@@ -1,6 +1,5 @@
-import { Menu } from "lucide-react";
-
 import { ThemeToggle } from "@/components/theme-toggle";
+import { MenuIcon } from "@/components/ui/icons";
 import type { NavigationItem } from "@/content/home";
 
 type SiteHeaderProps = Readonly<{
@@ -15,7 +14,7 @@ export function SiteHeader({ navigation }: SiteHeaderProps) {
 				style={{ animationDelay: "40ms" }}
 			>
 				<summary className="flex w-fit list-none items-center gap-2 rounded-full border border-border/70 bg-surface/88 px-4 py-2.5 font-mono text-[0.68rem] uppercase tracking-[0.16em] text-muted-foreground shadow-[var(--shadow-soft)] marker:hidden">
-					<Menu className="size-4" strokeWidth={1.8} />
+					<MenuIcon className="size-4" strokeWidth={1.8} />
 					Menu
 				</summary>
 

--- a/components/ui/icons.tsx
+++ b/components/ui/icons.tsx
@@ -1,0 +1,64 @@
+import type { SVGProps } from "react";
+
+type IconProps = SVGProps<SVGSVGElement>;
+
+export function GitHubIcon(props: IconProps) {
+	return (
+		<svg aria-hidden="true" fill="currentColor" viewBox="0 0 24 24" {...props}>
+			<path d="M12 2C6.48 2 2 6.58 2 12.26c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.5 0-.24-.01-.88-.01-1.73-2.78.62-3.37-1.37-3.37-1.37-.45-1.19-1.11-1.5-1.11-1.5-.91-.64.07-.63.07-.63 1 .07 1.53 1.06 1.53 1.06.9 1.57 2.35 1.12 2.92.85.09-.66.35-1.12.63-1.37-2.22-.26-4.55-1.14-4.55-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.31.1-2.72 0 0 .84-.28 2.75 1.05A9.42 9.42 0 0 1 12 6.96c.85 0 1.7.12 2.5.35 1.9-1.33 2.74-1.05 2.74-1.05.55 1.41.2 2.46.1 2.72.64.72 1.03 1.63 1.03 2.75 0 3.94-2.34 4.81-4.57 5.07.36.32.68.94.68 1.9 0 1.37-.01 2.47-.01 2.8 0 .28.18.6.69.5A10.23 10.23 0 0 0 22 12.26C22 6.58 17.52 2 12 2Z" />
+		</svg>
+	);
+}
+
+export function LinkedInIcon(props: IconProps) {
+	return (
+		<svg aria-hidden="true" fill="currentColor" viewBox="0 0 24 24" {...props}>
+			<path d="M6.94 8.87H3.73V20h3.21V8.87ZM5.33 4a1.86 1.86 0 1 0 0 3.72A1.86 1.86 0 0 0 5.33 4Zm15.16 9.9c0-3.28-1.75-4.8-4.08-4.8a3.53 3.53 0 0 0-3.18 1.75h-.04V8.87h-3.08V20h3.2v-5.5c0-1.45.27-2.86 2.07-2.86 1.77 0 1.79 1.67 1.79 2.95V20h3.21l.11-6.1Z" />
+		</svg>
+	);
+}
+
+export function MailIcon(props: IconProps) {
+	return (
+		<svg
+			aria-hidden="true"
+			fill="none"
+			stroke="currentColor"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			strokeWidth={2}
+			viewBox="0 0 24 24"
+			{...props}
+		>
+			<rect height="16" rx="2" width="20" x="2" y="4" />
+			<path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+		</svg>
+	);
+}
+
+export function MenuIcon(props: IconProps) {
+	return (
+		<svg
+			aria-hidden="true"
+			fill="none"
+			stroke="currentColor"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			strokeWidth={2}
+			viewBox="0 0 24 24"
+			{...props}
+		>
+			<path d="M4 12h16" />
+			<path d="M4 18h16" />
+			<path d="M4 6h16" />
+		</svg>
+	);
+}
+
+export function XIcon(props: IconProps) {
+	return (
+		<svg aria-hidden="true" fill="currentColor" viewBox="0 0 24 24" {...props}>
+			<path d="M13.86 10.47 21.15 2h-1.73l-6.33 7.35L8.04 2H2.21l7.65 11.12L2.21 22h1.73l6.69-7.76L15.96 22h5.83l-7.93-11.53Zm-2.37 2.75-.78-1.1L4.56 3.3h2.65l4.97 7.11.77 1.1 6.47 9.26h-2.65l-5.28-7.56Z" />
+		</svg>
+	);
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
 		"@vercel/speed-insights": "^2.0.0",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
-		"lucide-react": "^1.16.0",
 		"next": "^16.2.6",
 		"next-themes": "^0.4.6",
 		"react": "^19.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      lucide-react:
-        specifier: ^1.16.0
-        version: 1.16.0(react@19.2.6)
       next:
         specifier: ^16.2.6
         version: 16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -649,11 +646,6 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
-  lucide-react@1.16.0:
-    resolution: {integrity: sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1122,10 +1114,6 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
-
-  lucide-react@1.16.0(react@19.2.6):
-    dependencies:
-      react: 19.2.6
 
   magic-string@0.30.21:
     dependencies:


### PR DESCRIPTION
## Summary

Replaces the remaining icon dependency with a small local icon module.

Changes:
- adds `components/ui/icons.tsx` with the five site icons
- updates the contact section to import GitHub, LinkedIn, email, and `XIcon` from the local module
- updates the mobile header menu icon to use the local `MenuIcon`
- removes `lucide-react` from `package.json` and `pnpm-lock.yaml`

## Validation

- pnpm check
- pnpm build
- pnpm audit --audit-level moderate