### PR TITLE
chore: declare node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
 	"version": "0.1.0",
 	"private": true,
 	"packageManager": "pnpm@10.32.1",
+	"engines": {
+		"node": ">=22"
+	},
 	"scripts": {
 		"dev": "next dev",
 		"build": "next build",


### PR DESCRIPTION
## Summary

Declares the supported Node.js runtime in `package.json`.

This matches the Node 22 runtime already used by CI and makes the local development expectation explicit.

## Validation

- pnpm check
- pnpm build