### PR TITLE
chore: add verify workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  check:
-    name: Check
+  verify:
+    name: Verify
     runs-on: ubuntu-latest
 
     steps:
@@ -30,30 +30,5 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run Biome
-        run: pnpm check
-
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.32.1
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Run build
-        run: pnpm build
+      - name: Run verification
+        run: pnpm verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run verification
-        run: pnpm verify
+      - name: Run Biome
+        run: pnpm check
+
+      - name: Run TypeScript
+        run: pnpm typecheck
+
+      - name: Run build
+        run: pnpm build

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
 		"start": "next start",
 		"lint": "biome lint .",
 		"format": "biome format --write .",
-		"check": "biome check ."
+		"check": "biome check .",
+		"typecheck": "tsc --noEmit",
+		"verify": "pnpm check && pnpm typecheck && pnpm build"
 	},
 	"pnpm": {
 		"overrides": {


### PR DESCRIPTION
## Summary

Adds explicit local verification scripts and simplifies CI to one job while keeping each validation phase visible as its own step.

Changes:
- adds `typecheck` for standalone TypeScript validation
- adds `verify` for local end-to-end validation with Biome, TypeScript, and the production build
- replaces the duplicate CI check/build jobs with one `verify` job that installs dependencies once
- runs Biome, TypeScript, and build as separate CI steps after dependency installation

## Validation

- pnpm verify