### PR TITLE
chore: update pnpm to 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.32.1
+          version: 11.1.2
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "0xf000h.dev",
 	"version": "0.1.0",
 	"private": true,
-	"packageManager": "pnpm@10.32.1",
+	"packageManager": "pnpm@11.1.2",
 	"engines": {
 		"node": ">=22"
 	},
@@ -15,11 +15,6 @@
 		"check": "biome check .",
 		"typecheck": "tsc --noEmit",
 		"verify": "pnpm check && pnpm typecheck && pnpm build"
-	},
-	"pnpm": {
-		"overrides": {
-			"postcss": "8.5.14"
-		}
 	},
 	"dependencies": {
 		"@radix-ui/react-slot": "^1.2.4",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  sharp: false
+overrides:
+  postcss: 8.5.14


### PR DESCRIPTION
## Summary

Updates the repository pin from pnpm 10.32.1 to pnpm 11.1.2.

Changes:
- updates `packageManager` in `package.json`
- updates the CI pnpm setup version
- moves pnpm project settings into `pnpm-workspace.yaml`, which pnpm 11 reads for this configuration
- keeps the existing `postcss` override so Next resolves to the patched PostCSS version
- explicitly denies the `sharp` build script instead of approving native dependency builds for this site

## Validation

- corepack pnpm --version
- env CI=true corepack pnpm install --frozen-lockfile
- corepack pnpm verify
- corepack pnpm audit --audit-level moderate