### PR TITLE
chore: add app icon and gate vercel insights

### DIFF
--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+	<rect width="64" height="64" rx="14" fill="#0f172a" />
+	<path
+		d="M15 33.5 25.5 23l4.2 4.2-6.3 6.3 6.3 6.3-4.2 4.2L15 33.5Zm34 0L38.5 44l-4.2-4.2 6.3-6.3-6.3-6.3 4.2-4.2L49 33.5Z"
+		fill="#f8fafc"
+	/>
+</svg>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,6 +18,8 @@ const monoFont = Geist_Mono({
 	variable: "--font-code",
 });
 
+const shouldRenderVercelInsights = Boolean(process.env.VERCEL_ENV);
+
 export const metadata: Metadata = {
 	applicationName: siteConfig.name,
 	title: {
@@ -89,8 +91,12 @@ export default function RootLayout({ children }: RootLayoutProps) {
 				>
 					{children}
 				</ThemeProvider>
-				<Analytics />
-				<SpeedInsights />
+				{shouldRenderVercelInsights ? (
+					<>
+						<Analytics />
+						<SpeedInsights />
+					</>
+				) : null}
 			</body>
 		</html>
 	);


### PR DESCRIPTION
## Summary
- add a local `app/icon.svg` for the Next.js app icon route
- render Vercel Analytics and Speed Insights only when `VERCEL_ENV` is present

## Validation
- `pnpm verify`
- `pnpm audit`